### PR TITLE
Made cancel button text overridable and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ if (available.has) {
  
  | option | values | decription |
  | --- | --- | --- |
- | reason | any string | Popup label |
+ | reason | any string | Popup label for iOS|
+ | title | any string | Title of prompt in Android |
+ | subTitle | any string | Subtitle of prompt in Android |
+ | description | any string | Description of prompt in Android |
+ | cancel | any string | Text for cancel button on prompt in Android |
 
  ```ts
 const result = await BiometricAuth.verify({reason: "Message ..."})

--- a/android/src/main/java/com/ahm/capacitor/biometric/BiometricAuth.java
+++ b/android/src/main/java/com/ahm/capacitor/biometric/BiometricAuth.java
@@ -52,7 +52,7 @@ public class BiometricAuth extends Plugin {
                 .setTitle(call.getString("title", "Biometric"))
                 .setSubtitle(call.getString("subTitle", "Authentication is required to continue"))
                 .setDescription(call.getString("description", "This app uses biometric authentication to protect your data."))
-                .setNegativeButton("Cancel", context.getMainExecutor(), new DialogInterface.OnClickListener() {
+                .setNegativeButton(call.getString("cancel", "Cancel"), context.getMainExecutor(), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
                         call.reject("failed");


### PR DESCRIPTION
For a project I needed to provide Biometric authentication in a non-english app. The cancel button was hardcoded to the word "Cancel". I changed it along the lines of the titles and description to allow it to be overridden. I also added android specific information to the readme