### PR TITLE
Allow fallback to PIN/Password/Pattern on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ if (available.has) {
  | subTitle | any string | Subtitle of prompt in Android |
  | description | any string | Description of prompt in Android |
  | cancel | any string | Text for cancel button on prompt in Android |
+ | deviceCredentialAllowed | boolean | Allows fallback to PIN/Password/Pattern
 
  ```ts
 const result = await BiometricAuth.verify({reason: "Message ..."})

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,10 +11,10 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -44,4 +44,3 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
-

--- a/android/src/main/java/com/ahm/capacitor/biometric/BiometricAuth.java
+++ b/android/src/main/java/com/ahm/capacitor/biometric/BiometricAuth.java
@@ -48,17 +48,27 @@ public class BiometricAuth extends Plugin {
     private void displayBiometricPrompt(final PluginCall call) {
         Context context = getContext();
 
-        BiometricPrompt biometricPrompt = new BiometricPrompt.Builder(context)
-                .setTitle(call.getString("title", "Biometric"))
-                .setSubtitle(call.getString("subTitle", "Authentication is required to continue"))
-                .setDescription(call.getString("description", "This app uses biometric authentication to protect your data."))
-                .setNegativeButton(call.getString("cancel", "Cancel"), context.getMainExecutor(), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialogInterface, int i) {
-                        call.reject("failed");
-                    }
-                })
-                .build();
+        BiometricPrompt biometricPrompt = null;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q && call.getBoolean("deviceCredentialAllowed", false) == true) {
+            biometricPrompt = new BiometricPrompt.Builder(context)
+                    .setTitle(call.getString("title", "Biometric"))
+                    .setSubtitle(call.getString("subTitle", "Authentication is required to continue"))
+                    .setDescription(call.getString("description", "This app uses biometric authentication to protect your data."))
+                    .setDeviceCredentialAllowed(true)
+                    .build();
+        } else {
+            biometricPrompt = new BiometricPrompt.Builder(context)
+                    .setTitle(call.getString("title", "Biometric"))
+                    .setSubtitle(call.getString("subTitle", "Authentication is required to continue"))
+                    .setDescription(call.getString("description", "This app uses biometric authentication to protect your data."))
+                    .setNegativeButton(call.getString("cancel", "Cancel"), context.getMainExecutor(), new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                            call.reject("failed");
+                        }
+                    })
+                    .build();
+        }
         biometricPrompt.authenticate(getCancellationSignal(call), context.getMainExecutor(), getAuthenticationCallback(call));
     }
 


### PR DESCRIPTION
Requires API level 29 and already deprecated in favour of [`setAllowedAuthenticators`](https://developer.android.com/reference/android/hardware/biometrics/BiometricPrompt.Builder#setAllowedAuthenticators(int)) in API level 30. Seems it's rather immature 🤷